### PR TITLE
ci: fail on Hugo warnings

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -38,7 +38,7 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
       - name: Build with Hugo
-        run: hugo --environment production
+        run: hugo --environment production --panicOnWarning --minify
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- make Hugo build fail on warnings and produce minified output

## Testing
- `hugo --environment production --panicOnWarning --minify` *(fails: found no layout file for "html" for kind "page")*

------
https://chatgpt.com/codex/tasks/task_e_689aba02813c8332907c67039ee7ef55