### PR TITLE
Fix navbar logo link to home page

### DIFF
--- a/layouts/partials/sections/header.html
+++ b/layouts/partials/sections/header.html
@@ -50,7 +50,7 @@
     <nav class="pt-3 navbar navbar-expand-lg {{ if .Site.Params.animate }}animate{{ end }}">
         <div class="container-fluid mx-xs-2 mx-sm-5 mx-md-5 mx-lg-5">
             <!-- navbar brand -->
-            <a class="navbar-brand primary-font text-wrap" href="{{ .Site.Params.staticPath }}">
+            <a class="navbar-brand primary-font text-wrap" href="{{ .Site.BaseURL | relURL }}">
                 {{ if and (or (.Site.Params.favicon) (.Site.Params.navbar.brandLogo)) (.Site.Params.navbar.showBrandLogo | default true) }}
                 <img src="{{ .Site.Params.staticPath }}{{ .Site.Params.navbar.brandLogo | default .Site.Params.favicon }}" width="30" height="30"
                     class="d-inline-block align-top">


### PR DESCRIPTION
## Summary
- ensure top-left logo and brand name always link to site root

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_689abb4b84348332a0c90d23a67dd8d6