### PR TITLE
Use correct gallery menu title

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -37,7 +37,7 @@ Menus:
       weight: 1
     - identifier: gallery
       name: Gallery
-      title: Blog posts
+      title: Gallery
       url: /gallery
       weight: 2
     #Dropdown menu


### PR DESCRIPTION
## Summary
- Fix gallery menu title in hugo configuration

## Testing
- `hugo --quiet --destination /tmp/hugo-dist`


------
https://chatgpt.com/codex/tasks/task_e_689abb7780b083328ac91f191c9fa9ee