### PR TITLE
fix: use relative path for claude image

### DIFF
--- a/content/blogs/claude-code-next-gen-coding-assistant.md
+++ b/content/blogs/claude-code-next-gen-coding-assistant.md
@@ -3,7 +3,7 @@ title: "Claude Code: The Next Generation Developer Assistant"
 date: 2025-07-15T00:00:00Z
 tags: [AI, Developer Tools, Productivity, Claude]
 description: "Reflections on using Claude Code as a developer assistant for a month."
-image: "/images/claude-code-productivity.png"
+image: "images/claude-code-productivity.png"
 ---
 
 


### PR DESCRIPTION
## Summary
- use a relative link for the "Claude Code" blog post image so it resolves on GitHub Pages

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689adda8aee88332bc722120df127ec0