### PR TITLE
Use https for experience URLs

### DIFF
--- a/content/experience/americorps-nccc.md
+++ b/content/experience/americorps-nccc.md
@@ -1,6 +1,6 @@
 ---
 name: "Americorps NCCC"
-url: "www.nationalservice.gov/programs/americorps/americorps-nccc"
+url: "https://www.nationalservice.gov/programs/americorps/americorps-nccc"
 position: "Corpsmember"
 duration: "SEP 1995 - JUL 1996"
 summary: |

--- a/content/experience/fitch-solutions.md
+++ b/content/experience/fitch-solutions.md
@@ -1,6 +1,6 @@
 ---
 name: "Fitch Solutions"
-url: "www.fitchsolutions.com"
+url: "https://www.fitchsolutions.com"
 position: "Director, IT Product Development / Head of Platform Engineering"
 duration: "2015"
 summary: |

--- a/content/experience/springcm.md
+++ b/content/experience/springcm.md
@@ -1,6 +1,6 @@
 ---
 name: "SpringCM"
-url: "www.springcm.com"
+url: "https://www.springcm.com"
 position: "Sr. Director of Software Engineering"
 duration: "JAN 2007 - APR 2014"
 summary: "Served in various roles from UI Developer to Sr. Director of Software Engineering to build an enterprise class document management and business process automation solution."


### PR DESCRIPTION
## Summary
- prefix experience front matter URLs with `https://`

## Testing
- `hugo --destination /tmp/site` *(fails: URLs with protocol (http*) not supported in /content/experience/americorps-nccc.md)*

------
https://chatgpt.com/codex/tasks/task_e_689b44eebe148332983fd9ea3f8297e4