### PR TITLE
Use website field for experience entries

### DIFF
--- a/content/experience/americorps-nccc.md
+++ b/content/experience/americorps-nccc.md
@@ -1,6 +1,6 @@
 ---
 name: "Americorps NCCC"
-url: "https://www.nationalservice.gov/programs/americorps/americorps-nccc"
+website: "https://www.nationalservice.gov/programs/americorps/americorps-nccc"
 position: "Corpsmember"
 duration: "SEP 1995 - JUL 1996"
 summary: |

--- a/content/experience/fitch-solutions.md
+++ b/content/experience/fitch-solutions.md
@@ -1,6 +1,6 @@
 ---
 name: "Fitch Solutions"
-url: "https://www.fitchsolutions.com"
+website: "https://www.fitchsolutions.com"
 position: "Director, IT Product Development / Head of Platform Engineering"
 duration: "2015"
 summary: |

--- a/content/experience/springcm.md
+++ b/content/experience/springcm.md
@@ -1,6 +1,6 @@
 ---
 name: "SpringCM"
-url: "https://www.springcm.com"
+website: "https://www.springcm.com"
 position: "Sr. Director of Software Engineering"
 duration: "JAN 2007 - APR 2014"
 summary: "Served in various roles from UI Developer to Sr. Director of Software Engineering to build an enterprise class document management and business process automation solution."

--- a/docs/user/experience.md
+++ b/docs/user/experience.md
@@ -5,7 +5,7 @@ Experience entries live under `content/experience` and use YAML front matter wit
 | Field | Description |
 | ----- | ----------- |
 | `name` | Name of the employer or project. |
-| `url` | External link for additional information. |
+| `website` | External link for additional information. Include the protocol (`https://`). |
 | `position` | Job title or role. |
 | `duration` | Time period for the role (for example, `2015–2017`). |
 | `summary` | Short HTML or Markdown list of achievements. Use the `|` operator for multi-line content. |


### PR DESCRIPTION
## Summary
- avoid Hugo build error by renaming `url` to `website` in experience content
- document `website` field usage

## Testing
- `hugo --environment production --panicOnWarning --minify`


------
https://chatgpt.com/codex/tasks/task_e_689b4c0bd11083328e5081f9e4bc5d6f