### PR TITLE
chore: update production baseURL

### DIFF
--- a/config/production/hugo.toml
+++ b/config/production/hugo.toml
@@ -1,5 +1,5 @@
-baseURL = "https://mattjonesorg.github.io/mattjones.technology/"
+baseURL = "https://mattjones.technology/"
 relativeURLs = false
 uglyURLs = false
 [params]
-  staticPath = "/mattjones.technology"
+  staticPath = ""


### PR DESCRIPTION
## Summary
- point production config to https://mattjones.technology/
- clear static asset path

## Testing
- `hugo --environment production --panicOnWarning --minify` *(fails: found no layout file for "html" for kind "home")*

------
https://chatgpt.com/codex/tasks/task_e_689bc3bb12f48332a5618d8f3c5328a8